### PR TITLE
Implement std::error::Error for throw::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,12 @@ where
     }
 }
 
+impl<E> std::error::Error for Error<E>
+where
+    E: fmt::Display + fmt::Debug
+{
+}
+
 #[macro_export]
 macro_rules! up {
     ($e:expr) => (


### PR DESCRIPTION
Implement `std::error::Error` for `throw::Error`.